### PR TITLE
Removed dependency on deprecated package "uuid"

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,8 +16,7 @@ setup(
     long_description_content_type='text/markdown',
     url='https://github.com/Xtr4F/PyCharacterAI',
     packages=find_packages(),
-    install_requires=['uuid>=1.30',
-                      'curl-cffi==0.5.9'],
+    install_requires=['curl-cffi==0.5.9'],
     classifiers=[
         'Programming Language :: Python :: 3.10',
         'License :: OSI Approved :: MIT License'


### PR DESCRIPTION
The project lists `uuid` as a dependency. This causes `pip` to download the dependency from https://pypi.org/project/uuid/. This package is for older versions of Python and is not relevant now for following reasons:
1. Since Python 2.5 the `uuid` module is now a part of standard library. And installing it from PyPI is now deprecated. https://docs.python.org/3/whatsnew/2.5.html#:~:text=New%20module%3A%20the%20uuid%20module%20generates%20universally%20unique%20identifiers%20(UUIDs)%20according%20to%20RFC%204122.
2. The package causes errors during compilation in some environments. This error-prone behavior has been observed while I was using `PyCharacterAI` package in Cloud Functions on Yandex Cloud. The cloud apparently needs to compile Python, it could not compile `uuid` package because of some old code in the `uuid` package. Removing the `uuid` package from dependencies and using the built-in `uuid` module solved the problem.

Therefore, I removed `uuid` package from dependencies of `PyCharacterAI` project in this PR.  